### PR TITLE
add total plugin count and cumulative rating for all plugins

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -91,13 +91,15 @@ function wptally_shortcode( $atts, $content = null ) {
                     }
                 }
                 
+                $plugins_total = number_format( $count );
+                $plugins_reference = $plugins_total == 1 ? 'plugin' : 'plugins';
                 $cumulative_rating = $ratings_total / $ratings_count;
 
                 // Totals row
                 $results .= '<div class="tally-plugin">';
                 $results .= '<div class="tally-plugin-left">';
                     $results .= '<div class=tally-info">';
-                        $results .= '<p class=tally-count-rating">You have <span class=tally-count">' . number_format( $count ) . '</span> plugins with a cumulative rating of <span class=tally-rating">' . number_format( $cumulative_rating, 2, '.', '' ) . '</span> out of 5 stars</p>';
+                        $results .= '<p class=tally-count-rating">You have <span class=tally-count">' . $plugins_total . '</span> ' . $plugins_reference . ( empty( $ratings_count ) ? ' with no ratings.' : ' with a cumulative rating of <span class=tally-rating">' . number_format( $cumulative_rating, 2, '.', '' ) . '</span> out of 5 stars.</p>' );
                     $results .= '</div>';
                     $results .= '<div class=tally-share">';
                         $results .= '<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://wptally.com/?wpusername=' . esc_attr( $username ) . '" data-text="My plugins on WordPress.org have a total of ' . number_format( $total_downloads ) . ' downloads. Check it out on wptally.com">Tweet</a>


### PR DESCRIPTION
Alright, I took a stab at this: https://github.com/easydigitaldownloads/wp-tally/issues/7
- I didn't include any styles. I don't have the theme so that can easily be added. 
- I tried to do the cumulative rating math based on ratings (duh)... not plugins. For example, I have 6 plugins but only one has been rated. 
- I have no idea what I'm doing. So if this is a sh*t show, everyone just slowly walk away like it never happened. Also, teach me. :)
