### PR TITLE
No themes found word change #11

### DIFF
--- a/includes/class.wptally-api.php
+++ b/includes/class.wptally-api.php
@@ -170,7 +170,7 @@ class WPTally_API {
 
                 if( $count == 0 ) {
                     $data['themes'] = array(
-                        'error' => 'No plugins found for ' . $wp_query->query_vars['api']
+                        'error' => 'No themes found for ' . $wp_query->query_vars['api']
                     );
                 } else {
                     foreach( $themes as $theme ) {


### PR DESCRIPTION
When a username was added and they had zero themes in their profile, the page would say "no plugins found" instead of "no themes found"